### PR TITLE
(BOLT-1408) Add option to be consumed as a Bolt plugin

### DIFF
--- a/tasks/get.json
+++ b/tasks/get.json
@@ -9,6 +9,10 @@
     "count": {
       "description": "The number of VMs to get (default: 1)",
       "type": "Integer[1]"
+    },
+    "plugin": {
+      "description": "Whether to output bare string list, or list of inventory v2 compatible hashes",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/get.rb
+++ b/tasks/get.rb
@@ -7,6 +7,7 @@ args = JSON.parse(STDIN.read)
 
 platform = args['platform']
 count = args.fetch('count', 1)
+plugin = args.fetch('plugin', false)
 
 stdout, stderr, status = Open3.capture3('floaty', 'get', "#{platform}=#{count}", '--json')
 
@@ -17,7 +18,8 @@ if status != 0
 end
 
 nodes = Array(JSON.parse(stdout)[platform])
+nodes.map! { |n| { 'uri' => n } } if plugin
 
-result = {nodes: nodes}
+result = { targets: nodes }
 puts result.to_json
 exit 0


### PR DESCRIPTION
This adds an optional boolean parameter `plugin` which defaults to
false. When true, the output will be formatted as an array of hashes
which is compatible with the Bolt inventory task plugin.