### PR TITLE
Add inventory plugin to list active VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ This task retrieve a set of nodes from vmpooler.
 
 On success, the result will contain a `nodes` key, which is an array of the retrieved nodes. On failure, the result will contain an `_error` key describing the problem.
 
+#### `floaty::list`
+
+This task lists active VMs, and is intended to be used as a Bolt [inventory
+plugin](https://puppet.com/docs/bolt/latest/using_plugins.html).
+
+##### Output
+
+Returns the list of active VM hostnames under the 'value' key
+
+##### Parameters
+
+`platform` : Which VM pool to retrieve nodes from (ie. `centos-7-x86_64`)  
+`count` : How many nodes to retrieve (defaults to 1 if not specified)
+
+##### Output
+
+On success, the result will contain a `nodes` key, which is an array of the retrieved nodes. On failure, the result will contain an `_error` key describing the problem.
+
+
 ### Functions
 
 #### `floaty::get(platform, count)`

--- a/bolt_plugin.json
+++ b/bolt_plugin.json
@@ -1,0 +1,7 @@
+{
+  "hooks": {
+    "resolve_reference": {
+      "task": "floaty::list"
+    }
+  }
+}

--- a/tasks/list.json
+++ b/tasks/list.json
@@ -1,0 +1,3 @@
+{
+  "description": "Plugin to load active VMs to inventory"
+}

--- a/tasks/list.json
+++ b/tasks/list.json
@@ -1,3 +1,10 @@
 {
-  "description": "Plugin to load active VMs to inventory"
+  "description": "Plugin to load active VMs to inventory",
+  "input_method": "environment",
+  "parameters": {
+    "service": {
+      "type": "Optional[String]",
+      "description": "The pooler service to list VMs from"
+    }
+  }
 }

--- a/tasks/list.rb
+++ b/tasks/list.rb
@@ -1,18 +1,56 @@
 #!/usr/bin/env ruby
 
 require 'json'
+require 'yaml'
 require 'open3'
 
-stdout, stderr, status = Open3.capture3('floaty', 'list', '--active')
+# Try to predict which service output we'll get by reading the VMFloaty config
+# file and seeing if multiple services are defined. If none are, fall back to
+# vmpooler
+config_file = File.expand_path(File.join("~", ".vmfloaty.yml"))
+config = if File.exist?(config_file)
+           File.open(config_file, "r:UTF-8") do |f|
+             YAML.safe_load(f.read)
+           end
+         end
+service = ENV['PT_service'] || config&.dig('services')&.keys&.first || 'vmpooler'
 
+# List active VMs, specifying a service if provided
+cmd = %w[floaty list --active --json]
+cmd += %W[--service #{ENV['PT_service']}] if ENV['PT_service']
+stdout, stderr, status = Open3.capture3(*cmd)
+
+# Handle failures
 if status != 0
-  result = {_error: {msg: "Failed to execute floaty: #{stderr}", kind: "execution-error", details: {exitcode: status.exitstatus}}}
+  result = { _error: {
+    msg: "Failed to execute floaty: #{stderr}",
+    kind: "execution-error",
+    details: {
+      exitcode: status.exitstatus
+    }
+  } }
   puts result.to_json
   exit 1
 end
 
-targets = stdout.split("\n").drop(1)
-targets.map! { |t| t.split(' ')[1] }
+output = JSON.parse(stdout)
+targets = if service == 'abs'
+            output.values.dig(0, 'allocated_resources').map do |host|
+              host['hostname']
+            end
+          elsif service == 'vmpooler'
+            output.keys
+          else
+            result = { _error: {
+              msg: "VMFloaty service must be either 'abs' or 'vmpooler', got #{service}",
+              kind: "service-error",
+              details: {
+                exitcode: status.exitstatus
+              }
+            } }
+            puts result.to_json
+            exit 1
+          end
 
 result = { value: targets }
 puts result.to_json

--- a/tasks/list.rb
+++ b/tasks/list.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'open3'
+
+stdout, stderr, status = Open3.capture3('floaty', 'list', '--active')
+
+if status != 0
+  result = {_error: {msg: "Failed to execute floaty: #{stderr}", kind: "execution-error", details: {exitcode: status.exitstatus}}}
+  puts result.to_json
+  exit 1
+end
+
+targets = stdout.split("\n").drop(1)
+targets.map! { |t| t.split(' ')[1] }
+
+result = { value: targets }
+puts result.to_json
+exit 0


### PR DESCRIPTION
This adds a new task `floaty::list` which is intended for use as a Bolt
inventory plugin. It lists active VMs acquired through floaty and
returns the list of bare hostnames under the 'value' key. It does this
by running `floaty list --active` in a new process and munging the
output to a list of hostnames. The task doesn't currently accept
parameters, requiring users to configure their connection to vmpooler in
`~/.vmfloaty.yml`. This should be safe for now, as specifying connection
information on the command line is painful and it's expected most users
already do this.

This task allows floaty users to run bolt against their VMs
without making daily changes to their inventory file or manually
specifying the VM hostnames.